### PR TITLE
docs: Add link for [PostCSS] label

### DIFF
--- a/README-POSTCSS.md
+++ b/README-POSTCSS.md
@@ -90,5 +90,6 @@ body[\:has\(\:focus\)] {
 [npm-img]: https://img.shields.io/npm/v/css-has-pseudo.svg
 [npm-url]: https://www.npmjs.com/package/css-has-pseudo
 
+[PostCSS]: https://github.com/postcss/postcss
 [CSS Has Pseudo]: https://github.com/csstools/css-has-pseudo
 [Selectors Level 4]: https://drafts.csswg.org/selectors-4/#has-pseudo


### PR DESCRIPTION
At the moment, the text is linking to PostCSS but is not resolved due to the missing link at the bottom.
See other READMEs: https://raw.githubusercontent.com/csstools/postcss-is-pseudo-class/master/README.md